### PR TITLE
Adding @dev version parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ It will take care of autoloading your library's dependencies, and you won't have
 
 Studio can be installed per project or globally, with Composer:
 
-Per project: `composer require --dev franzliedke/studio`
+Per project: `composer require --dev franzliedke/studio:@dev`
 (use as `vendor/bin/studio`)
 
-Globally: `composer global require franzliedke/studio`
+Globally: `composer global require franzliedke/studio:@dev`
 (use as `studio`)
 
 ## Usage


### PR DESCRIPTION
Until this has a stable version @dev should be set to allow it to be installed in projects that have `stable` as their minimum stability. I wasn't able to get it to install without it.