### PR TITLE
Allow to use `studio create foo --submodule git@github.com:acme/foo.git`

### DIFF
--- a/src/Console/CreateCommand.php
+++ b/src/Console/CreateCommand.php
@@ -7,6 +7,7 @@ use Studio\Shell\Shell;
 use Studio\Config\Config;
 use Studio\Creator\CreatorInterface;
 use Studio\Creator\GitRepoCreator;
+use Studio\Creator\GitSubmoduleCreator;
 use Studio\Creator\SkeletonCreator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -57,6 +58,12 @@ class CreateCommand extends Command
                 'g',
                 InputOption::VALUE_REQUIRED,
                 'If set, this will download the given Git repository instead of creating a new one.'
+            )
+            ->addOption(
+                'submodule',
+                'gs',
+                InputOption::VALUE_REQUIRED,
+                'If set, this will download the given Git repository (as submodule) instead of creating a new one.'
             );
     }
 
@@ -92,6 +99,8 @@ class CreateCommand extends Command
 
         if ($input->getOption('git')) {
             return new GitRepoCreator($input->getOption('git'), $path);
+        } elseif ($input->getOption('submodule')) {
+            return new GitSubmoduleCreator($input->getOption('submodule'), $path);
         } else {
             $creator = new SkeletonCreator($path);
             $this->installParts($creator);

--- a/src/Creator/GitSubmoduleCreator.php
+++ b/src/Creator/GitSubmoduleCreator.php
@@ -2,34 +2,10 @@
 
 namespace Studio\Creator;
 
-use Studio\Package;
 use Studio\Shell\Shell;
 
-class GitSubmoduleCreator implements CreatorInterface
+class GitSubmoduleCreator extends GitRepoCreator
 {
-
-    protected $repo;
-
-    protected $path;
-
-
-    public function __construct($repo, $path)
-    {
-        $this->repo = $repo;
-        $this->path = $path;
-    }
-
-    /**
-     * Create the new package.
-     *
-     * @return \Studio\Package
-     */
-    public function create()
-    {
-        $this->cloneRepository();
-
-        return Package::fromFolder($this->path);
-    }
 
     protected function cloneRepository()
     {

--- a/src/Creator/GitSubmoduleCreator.php
+++ b/src/Creator/GitSubmoduleCreator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Studio\Creator;
+
+use Studio\Package;
+use Studio\Shell\Shell;
+
+class GitSubmoduleCreator implements CreatorInterface
+{
+
+    protected $repo;
+
+    protected $path;
+
+
+    public function __construct($repo, $path)
+    {
+        $this->repo = $repo;
+        $this->path = $path;
+    }
+
+    /**
+     * Create the new package.
+     *
+     * @return \Studio\Package
+     */
+    public function create()
+    {
+        $this->cloneRepository();
+
+        return Package::fromFolder($this->path);
+    }
+
+    protected function cloneRepository()
+    {
+        Shell::run("git submodule add $this->repo $this->path");
+        Shell::run("git submodule init");
+    }
+
+}


### PR DESCRIPTION
This would utilize git submodule instead of cloning the repository.
Useful for project that prefer such option.

Signed-off-by: crynobone <crynobone@gmail.com>