### PR TITLE
Generate relative path using available $baseDir instead of absolute path

### DIFF
--- a/src/Composer/StudioPlugin.php
+++ b/src/Composer/StudioPlugin.php
@@ -5,7 +5,6 @@ namespace Studio\Composer;
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
-use Composer\Package\RootPackage;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;

--- a/src/Composer/StudioPlugin.php
+++ b/src/Composer/StudioPlugin.php
@@ -5,6 +5,7 @@ namespace Studio\Composer;
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
+use Composer\Package\RootPackage;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use Composer\Script\ScriptEvents;
@@ -26,6 +27,11 @@ class StudioPlugin implements PluginInterface, EventSubscriberInterface
      */
     protected $io;
 
+    /**
+     * @var  string|null
+     */
+    protected $targetDir;
+
     public function activate(Composer $composer, IOInterface $io)
     {
         $this->composer = $composer;
@@ -42,8 +48,8 @@ class StudioPlugin implements PluginInterface, EventSubscriberInterface
 
     public function dumpAutoload(Event $event)
     {
-        $path = $event->getComposer()->getPackage()->getTargetDir();
-        $studioFile = "{$path}studio.json";
+        $this->targetDir = realpath($event->getComposer()->getPackage()->getTargetDir());
+        $studioFile = "{$this->targetDir}/studio.json";
 
         $config = $this->getConfig($studioFile);
         if ($config->hasPackages()) {
@@ -52,12 +58,14 @@ class StudioPlugin implements PluginInterface, EventSubscriberInterface
             $this->autoloadFrom($packages);
             $this->io->write('done');
         }
+
+        $this->targetDir = null;
     }
 
     public function update(Event $event)
     {
-        $path = $event->getComposer()->getPackage()->getTargetDir();
-        $studioFile = "{$path}studio.json";
+        $this->targetDir = realpath($event->getComposer()->getPackage()->getTargetDir());
+        $studioFile = "{$this->targetDir}/studio.json";
 
         $config = $this->getConfig($studioFile);
         if ($config->hasPackages()) {
@@ -69,6 +77,8 @@ class StudioPlugin implements PluginInterface, EventSubscriberInterface
                 $this->io->write('done');
             }
         }
+
+        $this->targetDir = null;
     }
 
     /**
@@ -119,12 +129,23 @@ class StudioPlugin implements PluginInterface, EventSubscriberInterface
             $end = "\n);\n";
 
             $lines = array_map(function ($value, $key) {
-                return '    ' . var_export($key, true) . ' => ' . var_export($value, true) . ',';
+                return '    ' . var_export($key, true) . ' => array(' . $this->parseAutoloadPath($value[0]) . '),';
             }, $newRules, array_keys($newRules));
 
             return $start . implode("\n", $lines) . $end;
         }, file_get_contents($autoloadFile));
 
         file_put_contents($autoloadFile, $contents);
+    }
+
+    protected function parseAutoloadPath($value)
+    {
+        $dir = var_export($value, true);
+
+        if (! is_dir($this->targetDir)) {
+            return $dir;
+        }
+
+        return str_replace("'{$this->targetDir}", "\$baseDir . '", $dir);
     }
 }


### PR DESCRIPTION
It would be useful to use available `$baseDir` when we can so that this would work nicely with VM.

E.g:

```php
    'Socieboy\\Forum\\' => array($baseDir . '/workbench/laravie/forum/vendor/socieboy/forum/src'),
    'Psr\\Log\\' => array($baseDir . '/workbench/laravie/forum/vendor/psr/log/Psr/Log'),
    'League\\CommonMark\\' => array($baseDir . '/workbench/laravie/forum/vendor/league/commonmark/src'),
    'Laravie\\Forum\\' => array($baseDir . '/workbench/laravie/forum/src'),
```

Signed-off-by: crynobone <crynobone@gmail.com>