### PR TITLE
Fix composer dump bug

### DIFF
--- a/src/Console/CreateCommand.php
+++ b/src/Console/CreateCommand.php
@@ -2,6 +2,7 @@
 
 namespace Studio\Console;
 
+use Studio\Package;
 use Studio\Parts\ConsoleInput;
 use Studio\Shell\Shell;
 use Studio\Config\Config;
@@ -83,7 +84,7 @@ class CreateCommand extends Command
         Shell::run('composer install --prefer-dist', $package->getPath());
         $output->writeln("<info>Package successfully created.</info>");
 
-        $this->refreshAutoloads($output);
+        $this->refreshAutoloads($output, $package);
     }
 
     /**
@@ -128,13 +129,14 @@ class CreateCommand extends Command
 
     /**
      * @param OutputInterface $output
+     * @param Package $package
      * @return void
      */
-    protected function refreshAutoloads(OutputInterface $output)
+    protected function refreshAutoloads(OutputInterface $output, Package $package)
     {
-        if (file_exists(getcwd() . 'composer.json')) {
+        if (file_exists(getcwd() . '/'  . $package->getPath() . '/composer.json')) {
             $output->writeln("<comment>Dumping autoloads...</comment>");
-            Shell::run('composer dump-autoload');
+            Shell::run('composer dump-autoload', $package->getPath());
             $output->writeln("<info>Autoloads successfully generated.</info>");
         }
     }


### PR DESCRIPTION
Without this fix **studio** searches for a new `composer.json` file and tries to run `composer dump` in the current directory, but not in the directory of the newly created project.

Similar problem is in the last 0.9.5 tag, but there **studio** doesn't check for the json file and runs `composer dump` straight from the current dir. This fires a composer error, that `composer.json` wasn't found:

```
[RuntimeException]
Error while running composer: Composer could not find a composer.json file in /Users/lanin/Projects/self
To initialize a project, please create a composer.json file as described in the https://getcomposer.org/ "Getting Started" section
```