### PR TITLE
Switch to new recommended syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "require": {
         "composer-plugin-api": "^1.0",
         "illuminate/support": "~5.0",
-        "symfony/console": "^2.7|^3.0",
-        "symfony/finder": "^2.5|^3.0",
-        "symfony/filesystem": "^2.5|^3.0",
-        "symfony/process": "^2.5|^3.0"
+        "symfony/console": "^2.7 || ^3.0",
+        "symfony/finder": "^2.5 || ^3.0",
+        "symfony/filesystem": "^2.5 || ^3.0",
+        "symfony/process": "^2.5 || ^3.0"
     },
     "require-dev": {
         "composer/composer": "dev-master",


### PR DESCRIPTION
Composer now recommends using `||` instead of single `|`.

https://getcomposer.org/doc/articles/versions.md#range