### PR TITLE
Update PHPUnit Example Test stub...

### DIFF
--- a/src/Parts/PhpUnit/stubs/tests/ExampleTest.php
+++ b/src/Parts/PhpUnit/stubs/tests/ExampleTest.php
@@ -2,7 +2,9 @@
 
 namespace Foo\Bar\Tests;
 
-class ExampleTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ExampleTest extends TestCase
 {
 
 }


### PR DESCRIPTION
to correctly reference the PHPUnit TestCase class.

I've noticed this evening that the package isn't referencing the PHPUnit framework class correctly.

I've fixed it by performing the steps in this pull request and so suggest that it is merged.