### PR TITLE
Add an --options argument to provide options to 'git clone' and 'git submodule add'

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ This will include things like configuration for testing tools, Travis CI, and au
 
 This will clone the given Git repository to the `bar` directory and install its dependencies.
 
+#### create --submodule: Manage existing packages by loading a Git repository as submodule
+
+    $ studio create bar --submodule git@github.com:me/myrepo.git
+
+This will load the given Git repository to the `bar` directory as a submodule and install its dependencies.
+
+#### create --options: Provide specific options to Git when loading the repository
+
+    $ studio create bar --git git@github.com:me/myrepo.git --options="--single-branch --branch=mybranch"
+    $ studio create bar --submodule git@github.com:me/myrepo.git --options="-b mybranch"
+
+This will load the given Git repository and checkout a specific branch.
+To have an overview of all the options available to you, check `git clone --help` and `git submodule add --help`.
+
 #### load: Make all packages from the given local path available to Composer
 
     $ studio load baz

--- a/src/Console/CreateCommand.php
+++ b/src/Console/CreateCommand.php
@@ -50,6 +50,12 @@ class CreateCommand extends BaseCommand
                 'gs',
                 InputOption::VALUE_REQUIRED,
                 'If set, this will download the given Git repository (as submodule) instead of creating a new one.'
+            )
+            ->addOption(
+                'options',
+                'go',
+                InputOption::VALUE_REQUIRED,
+                'If set, this will provide options to Git when fetching the repository or submodule.'
             );
     }
 
@@ -87,14 +93,16 @@ class CreateCommand extends BaseCommand
         $path = $input->getArgument('path');
 
         if ($input->getOption('git')) {
-            return new GitRepoCreator($input->getOption('git'), $path);
-        } elseif ($input->getOption('submodule')) {
-            return new GitSubmoduleCreator($input->getOption('submodule'), $path);
-        } else {
-            $creator = new SkeletonCreator($path);
-            $this->installParts($creator);
-            return $creator;
+            return new GitRepoCreator($input->getOption('git'), $path, $input->getOption('options'));
         }
+
+        if ($input->getOption('submodule')) {
+            return new GitSubmoduleCreator($input->getOption('submodule'), $path, $input->getOption('options'));
+        }
+
+        $creator = new SkeletonCreator($path);
+        $this->installParts($creator);
+        return $creator;
     }
 
     protected function installParts(SkeletonCreator $creator)

--- a/src/Creator/GitRepoCreator.php
+++ b/src/Creator/GitRepoCreator.php
@@ -11,11 +11,14 @@ class GitRepoCreator implements CreatorInterface
 
     protected $path;
 
+    protected $options;
 
-    public function __construct($repo, $path)
+
+    public function __construct($repo, $path, $options = '')
     {
         $this->repo = $repo;
         $this->path = $path;
+        $this->options = $options;
     }
 
     /**
@@ -32,6 +35,6 @@ class GitRepoCreator implements CreatorInterface
 
     protected function cloneRepository()
     {
-        Shell::run("git clone $this->repo $this->path");
+        Shell::run("git clone $this->options $this->repo $this->path");
     }
 }

--- a/src/Creator/GitSubmoduleCreator.php
+++ b/src/Creator/GitSubmoduleCreator.php
@@ -8,7 +8,7 @@ class GitSubmoduleCreator extends GitRepoCreator
 {
     protected function cloneRepository()
     {
-        Shell::run("git submodule add $this->repo $this->path");
+        Shell::run("git submodule add $this->options $this->repo $this->path");
         Shell::run("git submodule init");
     }
 }


### PR DESCRIPTION
I wanted to run `studio create --git ...` and checkout a specific branch. Here's the code that allows to do it and what it looks like : 

```bash
studio create packages/liip/functional-test-bundle --git git@github.com:gnutix/LiipFunctionalTestBundle.git --options="--single-branch --branch=symfony43compat"

studio create packages/liip/functional-test-bundle --submodule git@github.com:gnutix/LiipFunctionalTestBundle.git --options="-b symfony43compat"
```