### PR TITLE
Do not duplicate entries in studio.json.

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -61,9 +61,11 @@ class Config
         // Ensure paths are loaded
         $this->getPaths();
 
-        if (!in_array($path, $this->paths, true)) {
-            $this->paths[] = $path;
-        }
+        $this->paths[] = $path;
+
+        // Ensure there's no duplicates in paths
+        $this->paths = array_unique($this->paths);
+
         $this->dump();
     }
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -61,7 +61,9 @@ class Config
         // Ensure paths are loaded
         $this->getPaths();
 
-        $this->paths[] = $path;
+        if (!in_array($path, $this->paths, true)) {
+            $this->paths[] = $path;
+        }
         $this->dump();
     }
 


### PR DESCRIPTION
I guess the title says it all. If you run the `studio create` command several times (because you've removed the repositories for example and want to redo them), `studio.json` would currently contain multiple identical lines. This fixes it.