### PR TITLE
Commands must return an exit status

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "composer/composer": "dev-master",
-        "phpspec/phpspec": "~2.3"
+        "composer/composer": "1.10.x-dev",
+        "phpspec/phpspec": "^6.1"
     },
     "replace": {
         "franzliedke/studio": "self.version"

--- a/src/Console/BaseCommand.php
+++ b/src/Console/BaseCommand.php
@@ -33,8 +33,10 @@ abstract class BaseCommand extends Command
 
         try {
             $this->fire();
+            return 0;
         } catch (Exception $e) {
             $this->io->error($e->getMessage());
+            return 1;
         }
     }
 


### PR DESCRIPTION
Hi,

since Symfony 5 commands must return a status code, see:

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Command/Command.php#L261

So while the `composer.json` currently allows to install it with Symfony 5, running any command will just crash.