### PR TITLE
Export a clean array

### DIFF
--- a/spec/Config/Version2SerializerSpec.php
+++ b/spec/Config/Version2SerializerSpec.php
@@ -19,6 +19,7 @@ class Version2SerializerSpec extends ObjectBehavior
 
     function it_deduplicates_paths()
     {
-        $this->serializePaths(['foo', 'bar', 'foo'])->shouldReturn(['paths' => ['bar', 'foo']]);
+        // return array should have no gaps
+        $this->serializePaths(['bar', 'foo', 'test', 'foo'])->shouldReturn(['paths' => [0 => 'bar', 1 => 'foo', 2 => 'test']]);
     }
 }

--- a/src/Config/Version2Serializer.php
+++ b/src/Config/Version2Serializer.php
@@ -12,6 +12,6 @@ class Version2Serializer implements Serializer
     public function serializePaths(array $paths)
     {
         sort($paths);
-        return ['paths' => array_unique(array_values($paths))];
+        return ['paths' => array_values(array_unique($paths))];
     }
 }


### PR DESCRIPTION
`array_unique` preserves keys:

![2020-06-04 at 11 16](https://user-images.githubusercontent.com/1032411/83738609-cf15d680-a654-11ea-82ca-091f813a7fc0.png)

When serializing this will be exported as an indexed array in JSON:
![2020-06-04 at 11 13](https://user-images.githubusercontent.com/1032411/83738674-e359d380-a654-11ea-95ed-40b8058a1a61.png)

This fix will prevent this, as it will reindex the array (and therefor it can be serialized as a simple array):
![2020-06-04 at 11 17](https://user-images.githubusercontent.com/1032411/83738750-fcfb1b00-a654-11ea-9e2f-61a723357aa3.png)

I also modified the existing test, that this is covered with the test case.