### PR TITLE
Add end-to-end testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,5 @@ jobs:
                 run: php vendor/bin/phpspec run
 
             -   name: Run tests
-                run: php${{ matrix.php }} vendor/bin/simple-phpunit
+                run: php${{ matrix.php }} vendor/bin/simple-phpunit --testdox
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,20 +3,29 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  phpspec:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php: [7.2, 7.3, 7.4, 8.0]
-    steps:
-    - uses: actions/checkout@v1
-    - uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php }}
-    - name: Validate Composer files
-      run: composer validate --no-check-all --strict
-    - name: Install Composer dependencies
-      run: composer install --prefer-dist --no-progress --no-suggest
-    - name: Run tests
-      run: php vendor/bin/phpspec run
+    phpspec:
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                php: [7.2, 7.3, 7.4, 8.0]
+
+        steps:
+            -   uses: actions/checkout@v1
+
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+
+            -   name: Validate Composer files
+                run: composer validate --no-check-all --strict
+
+            -   name: Install Composer dependencies
+                run: composer install --prefer-dist --no-progress --no-suggest
+
+            -   name: Run tests
+                run: php vendor/bin/phpspec run
+
+            -   name: Run tests
+                run: php${{ matrix.php }} vendor/bin/simple-phpunit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,6 @@ jobs:
 
             -   name: Run PHPUnit
                 run: php vendor/bin/simple-phpunit --testdox
+                env:
+                    STUDIO_TESTS_BUILD_DIR: '${{ runner.temp }}/.studio-build'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,19 +3,32 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-    phpspec:
+    testsuite:
         runs-on: ubuntu-latest
 
         strategy:
             matrix:
-                php: [7.2, 7.3, 7.4, 8.0]
+                # only test the "borders" of supported versions, to minimize the number of test runs
+                # so minimum version, latest 7.x, and 8.x
+                php: ['7.2', '7.4', '8.0']
+                composer: ['v1', 'v2']
 
         steps:
             -   uses: actions/checkout@v1
 
             -   uses: shivammathur/setup-php@v2
                 with:
+                    coverage: "none"
+                    ini-values: "memory_limit=-1"
                     php-version: ${{ matrix.php }}
+                    tools: "composer:${{ matrix.composer }}"
+
+            -   name: Display versions
+                run: |
+                    php --version
+                    composer --version
+                    php -r 'foreach (get_loaded_extensions() as $extension) echo $extension . " " . phpversion($extension) . PHP_EOL;'
+                    php -i
 
             -   name: Validate Composer files
                 run: composer validate --no-check-all --strict
@@ -23,9 +36,9 @@ jobs:
             -   name: Install Composer dependencies
                 run: composer install --prefer-dist --no-progress --no-suggest
 
-            -   name: Run tests
+            -   name: Run PHPSpec
                 run: php vendor/bin/phpspec run
 
-            -   name: Run tests
-                run: php${{ matrix.php }} vendor/bin/simple-phpunit --testdox
+            -   name: Run PHPUnit
+                run: php vendor/bin/simple-phpunit --testdox
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-studio.json
-composer.phar
-composer.lock
-vendor/
+/.phpunit.result.cache
+/composer.lock
+/composer.phar
+/studio.json
+/vendor

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ To add a new test, create your fixtures sub directory in `tests/fixtures`, conta
 ```json
 {
 	"require": {
-		"franzl/studio": "dev-next"
+		"franzl/studio": "@dev"
 	},
 	"minimum-stability": "dev",
 	"repositories": [

--- a/README.md
+++ b/README.md
@@ -176,6 +176,30 @@ This means you can do almost anything with it, as long as the copyright notice a
 Feel free to send pull requests or create issues if you come across problems or have great ideas.
 Any input is appreciated!
 
+### Adding Integration Tests
+
+The package provides end-to-end tests to run composer with a local version of `studio` installed.
+
+To add a new test, create your fixtures sub directory in `tests/fixtures`, containing at least of a `composer.json` with this content:
+
+```json
+{
+	"require": {
+		"franzl/studio": "dev-next"
+	},
+	"minimum-stability": "dev",
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../../"
+		}
+	]
+}
+```
+
+Then you can add your test case in `tests/Runner/CliTest`.
+
+
 ## franzl/studio for enterprise
 
 Available as part of the Tidelift Subscription

--- a/README.md
+++ b/README.md
@@ -180,24 +180,12 @@ Any input is appreciated!
 
 The package provides end-to-end tests to run composer with a local version of `studio` installed.
 
-To add a new test, create your fixtures sub directory in `tests/fixtures`, containing at least of a `composer.json` with this content:
+To add a new test, create your fixtures sub directory in `tests/fixtures`, containing at least an empty `composer.json`. 
+Please note that the required installation changes to locally install `studio` in this test are done automatically.
 
-```json
-{
-	"require": {
-		"franzl/studio": "@dev"
-	},
-	"minimum-stability": "dev",
-	"repositories": [
-		{
-			"type": "path",
-			"url": "../../../"
-		}
-	]
-}
-```
+In a simple test you only need an empty `composer.json`.
 
-Then you can add your test case in `tests/Runner/CliTest`.
+After the setup, you can add your test case in `tests/Runner/CliTest`.
 
 
 ## franzl/studio for enterprise

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,11 @@
             "Studio\\": "src"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\Studio\\": "tests"
+        }
+    },
     "require": {
         "php": ">=7.0",
         "composer-plugin-api": "^1.0 || ^2.0",
@@ -17,8 +22,9 @@
         "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "composer/composer": "1.10.x-dev",
-        "phpspec/phpspec": "^6.3"
+        "composer/composer": "^2.0",
+        "phpspec/phpspec": "^6.3",
+        "symfony/phpunit-bridge": "^5.2"
     },
     "replace": {
         "franzliedke/studio": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
+        "ext-json": "*",
         "composer/composer": "^2.0",
         "phpspec/phpspec": "^6.3",
         "symfony/phpunit-bridge": "^5.2"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
+        <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="7.5" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Library tests">
+            <directory>tests</directory>
+            <exclude>tests/.build</exclude>
+            <exclude>tests/fixtures</exclude>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>src/</directory>
+        </whitelist>
+    </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+</phpunit>

--- a/spec/Config/Version2SerializerSpec.php
+++ b/spec/Config/Version2SerializerSpec.php
@@ -3,7 +3,6 @@
 namespace spec\Studio\Config;
 
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class Version2SerializerSpec extends ObjectBehavior
 {

--- a/tests/Runner/CliTest.php
+++ b/tests/Runner/CliTest.php
@@ -1,0 +1,128 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Studio\Runner;
+
+use Composer\Json\JsonManipulator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+
+final class CliTest extends TestCase
+{
+	private $fixturesDir;
+	private $composer;
+    private $buildDir;
+
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp ()
+    {
+        $this->composer = "composer";
+        $this->fixturesDir = \dirname(__DIR__) . "/fixtures";
+        $this->buildDir = "{$this->fixturesDir}/.build";
+
+        // Removes the build dir
+        $filesystem = new Filesystem();
+        $filesystem->remove($this->buildDir);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function tearDown ()
+    {
+        // Removes the build dir
+        $filesystem = new Filesystem();
+        $filesystem->remove($this->buildDir);
+    }
+
+
+    /**
+	 */
+	public function testList ()
+	{
+        $studioExecutable = $this->installFixture("list");
+
+		$output = (new Process([
+            $studioExecutable,
+			"list"
+		], $this->buildDir))
+			->mustRun()
+			->getOutput();
+
+		self::assertStringMatchesFormat("studio %d.%d.%d%a", $output);
+	}
+
+
+	/**
+	 */
+	public function testLoad ()
+	{
+		$studioExecutable = $this->installFixture("load");
+
+		$output = (new Process([
+            $studioExecutable,
+			"load",
+			"./sub-project"
+		], $this->buildDir))
+			->mustRun()
+			->getOutput();
+
+		$config = \json_decode(
+			\file_get_contents("{$this->buildDir}/studio.json"),
+			true
+		);
+
+		if (\json_last_error())
+		{
+			self::assertTrue(false, "JSON parsing failed");
+		}
+
+		// should be in the studio.json
+		self::assertContains("./sub-project", $config["paths"]);
+
+		// should install the package
+		// first: add the package manually
+		$composerJsonPath = "{$this->buildDir}/composer.json";
+		$package = new JsonManipulator(\file_get_contents($composerJsonPath));
+		$package->addSubNode("require", "franzl/studio-example", "^1.0");
+		\file_put_contents($composerJsonPath, $package->getContents());
+
+		$output = (new Process([
+			$this->composer,
+			"update",
+		], $this->buildDir))
+			->mustRun()
+            ->getErrorOutput();
+
+		self::assertStringContainsString("[Studio] Loading path ./sub-project", $output);
+		self::assertDirectoryExists("{$this->buildDir}/vendor/franzl/studio-example");
+	}
+
+
+
+
+	/**
+	 * Installs the fixture and returns the path to the studio executable
+	 */
+	private function installFixture (string $fixtureName) : string
+	{
+		$fixturePath = "{$this->fixturesDir}/{$fixtureName}";
+
+		// copy files to build dir
+		$filesystem = new Filesystem();
+		$filesystem->mirror($fixturePath, $this->buildDir);
+
+		// install studio
+		$process = new Process([
+			$this->composer,
+			"install"
+		], $this->buildDir);
+
+		$process->mustRun();
+
+		return "{$this->buildDir}/bin/studio";
+	}
+}

--- a/tests/fixtures/list/composer.json
+++ b/tests/fixtures/list/composer.json
@@ -1,12 +1,2 @@
 {
-	"require": {
-		"franzl/studio": "@dev"
-	},
-	"minimum-stability": "dev",
-	"repositories": [
-		{
-			"type": "path",
-			"url": "../../../"
-		}
-	]
 }

--- a/tests/fixtures/list/composer.json
+++ b/tests/fixtures/list/composer.json
@@ -1,0 +1,12 @@
+{
+	"require": {
+		"franzl/studio": "dev-next"
+	},
+	"minimum-stability": "dev",
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../../"
+		}
+	]
+}

--- a/tests/fixtures/list/composer.json
+++ b/tests/fixtures/list/composer.json
@@ -1,6 +1,6 @@
 {
 	"require": {
-		"franzl/studio": "dev-next"
+		"franzl/studio": "@dev"
 	},
 	"minimum-stability": "dev",
 	"repositories": [

--- a/tests/fixtures/load/composer.json
+++ b/tests/fixtures/load/composer.json
@@ -1,12 +1,2 @@
 {
-	"require": {
-		"franzl/studio": "@dev"
-	},
-	"minimum-stability": "dev",
-	"repositories": [
-		{
-			"type": "path",
-			"url": "../../../"
-		}
-	]
 }

--- a/tests/fixtures/load/composer.json
+++ b/tests/fixtures/load/composer.json
@@ -1,0 +1,12 @@
+{
+	"require": {
+		"franzl/studio": "dev-next"
+	},
+	"minimum-stability": "dev",
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../../"
+		}
+	]
+}

--- a/tests/fixtures/load/composer.json
+++ b/tests/fixtures/load/composer.json
@@ -1,6 +1,6 @@
 {
 	"require": {
-		"franzl/studio": "dev-next"
+		"franzl/studio": "@dev"
 	},
 	"minimum-stability": "dev",
 	"repositories": [

--- a/tests/fixtures/load/sub-project/composer.json
+++ b/tests/fixtures/load/sub-project/composer.json
@@ -1,0 +1,4 @@
+{
+	"name": "franzl/studio-example",
+	"version": "1.0.0"
+}


### PR DESCRIPTION
This PR adds support for end-to-end testing the plugin.

It basically uses the global composer command, installs the local version of the plugin and then you can add your own tests on top of that.

Right now only two tests are included:

1. whether the plugin works at all
2. to load a package + that composer then installs it correctly.

We should extend these tests to include all common commands, that are used with this package.


Questions for the future?
* As discussed: maybe remove the scaffolding part, to make this library as sharply focused as possible
* Add remaining tests cases (it will be a lot less if we remove scaffolding 😉 )
* Think about maybe moving the PHPSpec tests to PHPUnit? (I used PHPUnit because I am not quite sure on how to add these tests in PHPSpec)