### PR TITLE
drop support for php <8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0, 8.1]
+        php: [8.1, 8.2]
     steps:
     - uses: actions/checkout@v1
     - uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,20 @@ jobs:
       run: composer install --prefer-dist --no-progress
     - name: Run tests
       run: php vendor/bin/phpspec run
+  phpunit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [8.1, 8.2]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+    - name: Validate Composer files
+      run: composer validate --no-check-all --strict
+    - name: Install Composer dependencies
+      run: composer install --prefer-dist --no-progress
+    - name: Run tests
+      run: php vendor/bin/phpunit
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.phpunit.result.cache
 studio.json
 composer.phar
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,15 @@
         }
     },
     "require": {
-        "php": ">=7.0",
-        "composer-plugin-api": "^1.0 || ^2.0",
-        "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/filesystem": "^2.5 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
+        "php": ">=8.1",
+        "composer-plugin-api": "^2.3",
+        "symfony/console": "^6.2",
+        "symfony/filesystem": "^6.2",
+        "symfony/process": "^6.2"
     },
     "require-dev": {
-        "composer/composer": "^2.4.2",
-        "phpspec/phpspec": "^6.3 || ^7.0"
+        "composer/composer": "^2.5",
+        "phpspec/phpspec": "^7.4"
     },
     "replace": {
         "franzliedke/studio": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,11 @@
             "Studio\\": "src"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "StudioTests\\": "tests"
+        }
+    },
     "require": {
         "php": ">=8.1",
         "composer-plugin-api": "^2.3",
@@ -18,7 +23,9 @@
     },
     "require-dev": {
         "composer/composer": "^2.5",
-        "phpspec/phpspec": "^7.4"
+        "phpspec/phpspec": "^7.4",
+        "phpunit/phpunit": "^9.6 | ^10",
+        "mikey179/vfsstream": "^1.6.11"
     },
     "replace": {
         "franzliedke/studio": "self.version"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap = "vendor/autoload.php" colors = "true">
+
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>tests</directory>
+            <exclude>tests/**/stubs</exclude>
+        </testsuite>
+    </testsuites>
+
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_VERSION" value="0.15.0"/>
+    </php>
+
+</phpunit>

--- a/src/Creator/SkeletonCreator.php
+++ b/src/Creator/SkeletonCreator.php
@@ -49,7 +49,7 @@ class SkeletonCreator implements CreatorInterface
 
     protected function installParts()
     {
-        $config = new \stdClass();
+        $config = (object)[];
 
         foreach ($this->parts as $part) {
             $part->setupPackage($config, $this->directory);

--- a/src/Parts/Composer/Part.php
+++ b/src/Parts/Composer/Part.php
@@ -27,7 +27,7 @@ class Part extends AbstractPart
         // Normalize and store the namespace
         $namespace = str_replace('/', '\\', $namespace);
         $namespace = rtrim($namespace, '\\');
-        @$composer->autoload->{'psr-4'}->{"$namespace\\"} = 'src/';
+        $composer->autoload = (object)['psr-4' => (object)["$namespace\\" => 'src/']];
 
         // Create an example file
         $this->copyTo(

--- a/src/Parts/PhpSpec/Part.php
+++ b/src/Parts/PhpSpec/Part.php
@@ -10,7 +10,7 @@ class Part extends AbstractPart
     public function setupPackage($composer, Directory $target)
     {
         if ($this->input->confirm('Do you want to set up PhpSpec as a testing tool?')) {
-            $composer->{'require-dev'}['phpspec/phpspec'] = '^4.0';
+            $composer->{'require-dev'}['phpspec/phpspec'] = '^7.4';
 
             $psr4Autoloading = (array) $composer->autoload->{'psr-4'};
             $namespace = key($psr4Autoloading).'Tests';

--- a/src/Parts/PhpUnit/Part.php
+++ b/src/Parts/PhpUnit/Part.php
@@ -10,13 +10,13 @@ class Part extends AbstractPart
     public function setupPackage($composer, Directory $target)
     {
         if ($this->input->confirm('Do you want to set up PhpUnit as a testing tool?')) {
-            $composer->{'require-dev'}['phpunit/phpunit'] = '^6.3';
+            $composer->{'require-dev'}['phpunit/phpunit'] = '^9.6 || ^10';
 
             // Add autoloading rules for tests
             $psr4Autoloading = (array) $composer->autoload->{'psr-4'};
             $namespace = key($psr4Autoloading).'Tests';
 
-            @$composer->{'autoload-dev'}->{'psr-4'}->{"$namespace\\"} = 'tests/';
+            $composer->{'autoload-dev'} = (object)['psr-4' => (object)["$namespace\\" => 'tests/']];
 
             // Create an example test file
             $this->copyTo(

--- a/tests/Console/AbstractConsoleTest.php
+++ b/tests/Console/AbstractConsoleTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace StudioTests\Console;
+
+use PHPUnit\Framework\TestCase;
+use Studio\Console\CreateCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+abstract class AbstractConsoleTest extends TestCase
+{
+    protected function executeCommand(array $arguments, array $inputs = []): CommandTester
+    {
+        $application = new Application('studio', getenv('APP_VERSION'));
+        $application->add(new CreateCommand);
+
+        // this uses a special testing container that allows you to fetch private services
+        /** @var Command $command */
+        $command = $application->get($this->getCommandFqcn());
+
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs($inputs);
+        $commandTester->execute($arguments);
+
+        return $commandTester;
+    }
+
+    abstract protected function getCommandFqcn(): string;
+}

--- a/tests/Console/CreateTest.php
+++ b/tests/Console/CreateTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace StudioTests\Console;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\visitor\vfsStreamStructureVisitor;
+
+class CreateTest extends AbstractConsoleTest
+{
+    private $root;
+
+    public function setUp(): void
+    {
+        $this->root = vfsStream::setup();
+    }
+
+    function testExecute(): void
+    {
+        $commandTester = $this->executeCommand(
+            ['path' => $this->root->url() . '/company/my-package'],
+            [
+                // package name
+                'company/my-package',
+                // default namespace (psr-4)
+                'Company/MyPackage',
+                // set up PhpUnit
+                'yes',
+                // set up PhpSpec
+                'yes',
+                // set up TravisCI
+                'yes'
+            ]
+        );
+
+        $this->assertEquals(
+            self::getStructure(),
+            vfsStream::inspect(new vfsStreamStructureVisitor())->getStructure()
+        );
+    }
+
+    protected function getCommandFqcn(): string
+    {
+        return 'create';
+    }
+
+    protected static function getStructure(): array
+    {
+        return [
+            'root' => [
+                'company' => [
+                    'my-package' => [
+                        'spec' => [],
+                        'src' => [
+                            'Example.php' => file_get_contents(__DIR__ . '/stubs/company/my-package/src/Example.php'),
+                        ],
+                        'tests' => [
+                            'ExampleTest.php' => file_get_contents(__DIR__ . '/stubs/company/my-package/tests/ExampleTest.php'),
+                        ],
+                        '.gitignore' => file_get_contents(__DIR__ . '/stubs/company/my-package/.gitignore'),
+                        '.travis.yml' => file_get_contents(__DIR__ . '/stubs/company/my-package/.travis.yml'),
+                        'composer.json' => file_get_contents(__DIR__ . '/stubs/company/my-package/composer.json'),
+                        'phpspec.yml' => file_get_contents(__DIR__ . '/stubs/company/my-package/phpspec.yml'),
+                        'phpunit.xml' => file_get_contents(__DIR__ . '/stubs/company/my-package/phpunit.xml'),
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Console/stubs/company/my-package/.gitignore
+++ b/tests/Console/stubs/company/my-package/.gitignore
@@ -1,0 +1,3 @@
+composer.phar
+composer.lock
+vendor

--- a/tests/Console/stubs/company/my-package/.travis.yml
+++ b/tests/Console/stubs/company/my-package/.travis.yml
@@ -1,0 +1,13 @@
+language: php
+
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+
+before_script:
+  - travis_retry composer self-update
+  - travis_retry composer install --prefer-source --no-interaction --dev
+
+script: phpunit

--- a/tests/Console/stubs/company/my-package/composer.json
+++ b/tests/Console/stubs/company/my-package/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "company/my-package",
+    "autoload": {
+        "psr-4": {
+            "Company\\MyPackage\\": "src/"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6 || ^10",
+        "phpspec/phpspec": "^7.4"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Company\\MyPackage\\Tests\\": "tests/"
+        }
+    }
+}

--- a/tests/Console/stubs/company/my-package/phpspec.yml
+++ b/tests/Console/stubs/company/my-package/phpspec.yml
@@ -1,0 +1,4 @@
+suites:
+  library_suite:
+    namespace: Company\MyPackage\Tests
+    psr4_prefix: Company\MyPackage\Tests

--- a/tests/Console/stubs/company/my-package/phpunit.xml
+++ b/tests/Console/stubs/company/my-package/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         verbose="true"
+        >
+    <testsuites>
+        <testsuite name="Package Test Suite">
+            <directory suffix=".php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Console/stubs/company/my-package/src/Example.php
+++ b/tests/Console/stubs/company/my-package/src/Example.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Company\MyPackage;
+
+class Example
+{
+
+}

--- a/tests/Console/stubs/company/my-package/tests/ExampleTest.php
+++ b/tests/Console/stubs/company/my-package/tests/ExampleTest.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Company\MyPackage\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class ExampleTest extends TestCase
+{
+
+}


### PR DESCRIPTION
studio create throws an error using PHP 8.2

`Fatal error: Uncaught Error: Attempt to modify property "psr-4" on null in /Users/head/.composer/vendor/franzl/studio/src/Parts/PhpUnit/Part.php:19
Stack trace:
#0 /Users/head/.composer/vendor/franzl/studio/src/Creator/SkeletonCreator.php(55): Studio\Parts\PhpUnit\Part->setupPackage(Object(stdClass), Object(Studio\Filesystem\Directory))
#1 /Users/head/.composer/vendor/franzl/studio/src/Creator/SkeletonCreator.php(45): Studio\Creator\SkeletonCreator->installParts()
#2 /Users/head/.composer/vendor/franzl/studio/src/Console/CreateCommand.php(68): Studio\Creator\SkeletonCreator->create()
#3 /Users/head/.composer/vendor/franzl/studio/src/Console/BaseCommand.php(35): Studio\Console\CreateCommand->fire()
#4 /Users/head/.composer/vendor/symfony/console/Command/Command.php(312): Studio\Console\BaseCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 /Users/head/.composer/vendor/symfony/console/Application.php(1022): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /Users/head/.composer/vendor/symfony/console/Application.php(314): Symfony\Component\Console\Application->doRunCommand(Object(Studio\Console\CreateCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /Users/head/.composer/vendor/symfony/console/Application.php(168): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /Users/head/.composer/vendor/franzl/studio/bin/studio(30): Symfony\Component\Console\Application->run()
#9 /Users/head/.composer/vendor/bin/studio(120): include('/Users/head/.co...')
#10 {main}
  thrown in /Users/head/.composer/vendor/franzl/studio/src/Parts/PhpUnit/Part.php on line 19`